### PR TITLE
ISO Filters v2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,21 @@ python:
   - '2.7'
   - '3.5'
   - '3.6'
-install: pip install .
-script: python setup.py test
+
+install:
+  - pip install .
+  - pip install docutils pygments  # Used to check package metadata.
+
+script:
+  - python setup.py check --strict --metadata --restructuredtext
+  - python setup.py test
+
 deploy:
-- on:
-    python: '3.6'
-    tags: true
-  provider: pypi
-  distributions: 'bdist_wheel sdist'
-  user: efl_phx
-  password:
-    secure: aZx2Op+s+bGY+EsRbJO6PuluVu0g4/KE2Y9BkD9XajRDASoyUt0pWzUNU7FhvLkfPu0LmnzHgGPRMgeVzLMhxiSF/trAyWTnxSe+wQoVrhyV86uiiwBuyJfQrwbfRi61eKzi0m+j0douuBOSRbT8YSg38L9qYMzBFn6TsKZjQlAxOCSxlhfS/Q5I5+n+5aj4ZHCTXfNSZh5MnVFVT9ZJny9y23P4rYkgZb1eeXwUJJBHdfPQHkwNRmotP4cKiqZt1+SrFWqmwfnasIuv+EgZZ4vs7bPdfhH2x0lT4fBIAdV9SpyaqXOdH3VLWQ5U2IeBHNYYPHuQDjZS1VX0sZfON1GMCPkEC14RUpv8FaJzvIpW4KG95dBjGf9HPiFQm4YpWrkExc0u97yCrzwrGur+Z6plJozDk8d1GM9h8EDhSvKPhbWnJvH7kc8bUqqDFH1ZtIqB6pA4i36fNqOx+yM4B2zVvU1hi6LBSayatW3JXYfYT8QbtM319WU2yvtM85GptmeFRcfbOGa5SYJqFrj30MjemCwD7m4LjH8kPP/15vK7Eo96aJe5dXH3p7uwYQ0JVpoQGupvghJCAiW7c6dLY+SYH9l7ybQKbAHomXUi9F9hD1sQxuQRA/N0O819CQpA7IslAKsBBpgoe4Nd3bqhzb0D+pxAsMldFQYsOEThMnw=
+  - on:
+      python: '3.6'
+      tags: true
+    provider: pypi
+    distributions: 'bdist_wheel sdist'
+    user: efl_phx
+    password:
+      secure: aZx2Op+s+bGY+EsRbJO6PuluVu0g4/KE2Y9BkD9XajRDASoyUt0pWzUNU7FhvLkfPu0LmnzHgGPRMgeVzLMhxiSF/trAyWTnxSe+wQoVrhyV86uiiwBuyJfQrwbfRi61eKzi0m+j0douuBOSRbT8YSg38L9qYMzBFn6TsKZjQlAxOCSxlhfS/Q5I5+n+5aj4ZHCTXfNSZh5MnVFVT9ZJny9y23P4rYkgZb1eeXwUJJBHdfPQHkwNRmotP4cKiqZt1+SrFWqmwfnasIuv+EgZZ4vs7bPdfhH2x0lT4fBIAdV9SpyaqXOdH3VLWQ5U2IeBHNYYPHuQDjZS1VX0sZfON1GMCPkEC14RUpv8FaJzvIpW4KG95dBjGf9HPiFQm4YpWrkExc0u97yCrzwrGur+Z6plJozDk8d1GM9h8EDhSvKPhbWnJvH7kc8bUqqDFH1ZtIqB6pA4i36fNqOx+yM4B2zVvU1hi6LBSayatW3JXYfYT8QbtM319WU2yvtM85GptmeFRcfbOGa5SYJqFrj30MjemCwD7m4LjH8kPP/15vK7Eo96aJe5dXH3p7uwYQ0JVpoQGupvghJCAiW7c6dLY+SYH9l7ybQKbAHomXUi9F9hD1sQxuQRA/N0O819CQpA7IslAKsBBpgoe4Nd3bqhzb0D+pxAsMldFQYsOEThMnw=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-dist: trusty
 language: python
 python:
-  - '2.7'
   - '3.5'
   - '3.6'
+  - '3.7'
+  - '3.8'
 
 install:
   - pip install .
@@ -14,11 +14,11 @@ script:
   - python setup.py test
 
 deploy:
-  - on:
-      python: '3.6'
-      tags: true
-    provider: pypi
-    distributions: 'bdist_wheel sdist'
-    user: efl_phx
-    password:
-      secure: aZx2Op+s+bGY+EsRbJO6PuluVu0g4/KE2Y9BkD9XajRDASoyUt0pWzUNU7FhvLkfPu0LmnzHgGPRMgeVzLMhxiSF/trAyWTnxSe+wQoVrhyV86uiiwBuyJfQrwbfRi61eKzi0m+j0douuBOSRbT8YSg38L9qYMzBFn6TsKZjQlAxOCSxlhfS/Q5I5+n+5aj4ZHCTXfNSZh5MnVFVT9ZJny9y23P4rYkgZb1eeXwUJJBHdfPQHkwNRmotP4cKiqZt1+SrFWqmwfnasIuv+EgZZ4vs7bPdfhH2x0lT4fBIAdV9SpyaqXOdH3VLWQ5U2IeBHNYYPHuQDjZS1VX0sZfON1GMCPkEC14RUpv8FaJzvIpW4KG95dBjGf9HPiFQm4YpWrkExc0u97yCrzwrGur+Z6plJozDk8d1GM9h8EDhSvKPhbWnJvH7kc8bUqqDFH1ZtIqB6pA4i36fNqOx+yM4B2zVvU1hi6LBSayatW3JXYfYT8QbtM319WU2yvtM85GptmeFRcfbOGa5SYJqFrj30MjemCwD7m4LjH8kPP/15vK7Eo96aJe5dXH3p7uwYQ0JVpoQGupvghJCAiW7c6dLY+SYH9l7ybQKbAHomXUi9F9hD1sQxuQRA/N0O819CQpA7IslAKsBBpgoe4Nd3bqhzb0D+pxAsMldFQYsOEThMnw=
+  on:
+    python: '3.7'
+    tags: true
+  provider: pypi
+  user: phx
+  password:
+    secure: "E+K6YCYtaDJKBrZWxDG2o8BMzYmLZsLeaiKTZtYu2q1NSZ+DTs06KGmSR9Wu+lLxoVkZvPNJEPwSDTCe5N0JyOW/MmlzYdWiGB+Q/+9O8s1nHqyvoMN02hpZ9YiC97YtjpZk53DKvrRE6UrS6o6cruzLqyCr3XexYZLujtzZqQJbzmWtx9+SVMQgImKTOtTQxCH9ZELgn+e67Ko+T4ORTUWwROM9HKqJ6TSJjWEfuC6jIt9/D8+YGZpe/F8L3SLO1pkiI7DrrlE17W1QrDDO9dLWX6XWvuLskVtouIUaStfL2m1aRUczS5skYw6kn1rl/m09VfjeG1QR7piNHZC02opnBeauKU+S8RYShSwbrBGBoSqKa+wYnQPg5TI2vjR5fF88VhPPIgK84R3+ROF/dRrRX1ttWFD7xrfJlCBrwK0WqnKLXz6D2NCjpxzi/R/twjKRGuKR210IhKjm0soW9X1Q8+bQqxRIoayYhmMad1zMhSdF3g8+zwCnFr0R9/wF5JaLz35OKGqmWBcrHJ+6Juky1v0NDRI8l/MogeUyIeqUR3N1E5toOLhSfZC347rj+nHZ1Ft6tqO1/LtyyMXHL3ZBGrMGNqO/qe3QnVsr5wECP4EWV2h9c9h8SR3xex9v+9F8App+VKo06ywLsnUVpxnBPY+9mrB6pa3lapBuRBw="
+  distributions: 'bdist_wheel sdist'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - '3.5'
   - '3.6'
   - '3.7'
-  - '3.8'
+  - '3.8-dev'
 
 install:
   - pip install .

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,8 @@
-.. image:: https://travis-ci.org/eflglobal/filters-iso.svg?branch=master
-   :target: https://travis-ci.org/eflglobal/filters-iso
+.. image:: https://travis-ci.org/todofixthis/filters-iso.svg?branch=master
+   :target: https://travis-ci.org/todofixthis/filters-iso
 .. image:: https://readthedocs.org/projects/filters/badge/?version=latest
    :target: http://filters.readthedocs.io/
 
-
-===========
 ISO Filters
 ===========
 Adds filters for interpreting standard codes and identifiers, including:
@@ -13,19 +11,18 @@ Adds filters for interpreting standard codes and identifiers, including:
 - ISO 4217 currency codes.
 - IETF Language Tags (aka BCP 47).
 
-
 Installation
 ------------
 This package is an extension for the `Filters library`, so you can install it
-as an extra to ``filters``::
+as an extra to ``phx-filters``::
 
-   pip install filters[iso]
+   pip install phx-filters[iso]
 
 
 If desired, you can install this package separately.  This allows you to control
-the package version separately from ``filters``::
+the package version separately from ``phx-filters``::
 
-   pip install filters-iso
+   pip install phx-filters-iso
 
 
 Running Unit Tests
@@ -37,16 +34,12 @@ To run unit tests after installing from source::
 This project is also compatible with `tox`_, which will run the unit tests in
 different virtual environments (one for each supported version of Python).
 
-To run the unit tests, it is recommended that you use the `detox`_ library.
-detox speeds up the tests by running them in parallel.
-
 Install the package with the ``test-runner`` extra to set up the necessary
-dependencies, and then you can run the tests with the ``detox`` command::
+dependencies, and then you can run the tests with the ``tox`` command::
 
   pip install -e .[test-runner]
-  detox -v
+  tox -p all
 
 
 .. _Filters library: https://pypi.python.org/pypi/filters
-.. _detox: https://pypi.python.org/pypi/detox
 .. _tox: https://tox.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@
 .. image:: https://readthedocs.org/projects/filters/badge/?version=latest
    :target: http://filters.readthedocs.io/
 
+
 ===========
 ISO Filters
 ===========
@@ -12,23 +13,40 @@ Adds filters for interpreting standard codes and identifiers, including:
 - ISO 4217 currency codes.
 - IETF Language Tags (aka BCP 47).
 
-------------
+
 Installation
 ------------
 This package is an extension for the `Filters library`, so you can install it
-as an extra to ``filters``:
-
-.. code:: bash
+as an extra to ``filters``::
 
    pip install filters[iso]
 
 
 If desired, you can install this package separately.  This allows you to control
-the package version separately from ``filters``.
-
-.. code:: bash
+the package version separately from ``filters``::
 
    pip install filters-iso
 
 
+Running Unit Tests
+------------------
+To run unit tests after installing from source::
+
+  python setup.py test
+
+This project is also compatible with `tox`_, which will run the unit tests in
+different virtual environments (one for each supported version of Python).
+
+To run the unit tests, it is recommended that you use the `detox`_ library.
+detox speeds up the tests by running them in parallel.
+
+Install the package with the ``test-runner`` extra to set up the necessary
+dependencies, and then you can run the tests with the ``detox`` command::
+
+  pip install -e .[test-runner]
+  detox -v
+
+
 .. _Filters library: https://pypi.python.org/pypi/filters
+.. _detox: https://pypi.python.org/pypi/detox
+.. _tox: https://tox.readthedocs.io/

--- a/filters_iso/__init__.py
+++ b/filters_iso/__init__.py
@@ -1,9 +1,4 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
 from filters.base import BaseFilter, Type
-from six import string_types
 
 __all__ = [
     'Country',
@@ -28,13 +23,14 @@ class Country(BaseFilter):
     def _apply(self, value):
         # Lazy-load dependencies to reduce memory usage when this
         # filter is not used in a project.
+        # noinspection PyProtectedMember
         from iso3166 import (
             countries_by_alpha2,
             countries_by_alpha3,
             Country as CountryType,
         )
 
-        value = self._filter(value, Type(string_types + (CountryType,)))
+        value = self._filter(value, Type((str, CountryType,)))
 
         if self._has_errors:
             return None
@@ -74,7 +70,7 @@ class Currency(BaseFilter):
             get_currency,
         )
 
-        value = self._filter(value, Type(string_types + (CurrencyType,)))
+        value = self._filter(value, Type((str, CurrencyType,)))
 
         if self._has_errors:
             return None
@@ -116,7 +112,7 @@ class Locale(BaseFilter):
         from language_tags import tags
         from language_tags.Tag import Tag
 
-        value = self._filter(value, Type(string_types + (Tag,)))
+        value = self._filter(value, Type((str, Tag,)))
 
         if self._has_errors:
             return None
@@ -128,13 +124,13 @@ class Locale(BaseFilter):
 
         if not tag.valid:
             return self._invalid_value(
-                value   = value,
-                reason  = self.CODE_INVALID,
+                value=value,
+                reason=self.CODE_INVALID,
 
-                context = {
+                context={
                     'parse_errors': [
                         (error.code, error.message)
-                            for error in tag.errors
+                        for error in tag.errors
                     ],
                 },
             )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ setup(
         'py-moneyed',
     ],
 
+    extras_require = {
+        'test-runner': ['detox'],
+    },
+
     test_suite    = 'test',
     test_loader   = 'nose.loader:TestLoader',
     tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,3 @@
-# coding=utf-8
-# :bc: Not importing unicode_literals because in Python 2 distutils,
-# some values are expected to be byte strings.
-from __future__ import absolute_import, division, print_function
-
 from codecs import StreamReader, open
 from os.path import dirname, join, realpath
 
@@ -12,23 +7,22 @@ cwd = dirname(realpath(__file__))
 
 ##
 # Load long description for PyPi.
-with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f: # type: StreamReader
+with open(join(cwd, 'README.rst'), 'r', 'utf-8') as f:  # type: StreamReader
     long_description = f.read()
-
 
 ##
 # Off we go!
 setup(
-    name        = 'filters-iso',
-    description = 'Adds filters for interpreting ISO codes.',
-    url         = 'https://filters.readthedocs.io/',
+    name='phx-filters-iso',
+    description='Adds filters for interpreting ISO codes.',
+    url='https://filters.readthedocs.io/',
 
-    version = '1.0.3',
+    version='2.0.0',
 
-    packages = ['filters_iso'],
+    packages=['filters_iso'],
 
     # Install package filters into the global registry.
-    entry_points = {
+    entry_points={
         'filters.extensions': [
             'Country = filters_iso:Country',
             'Currency = filters_iso:Currency',
@@ -36,44 +30,43 @@ setup(
         ],
     },
 
-    long_description = long_description,
+    long_description=long_description,
 
-    install_requires = [
-        'filters >= 1.2.0',
+    install_requires=[
+        'phx-filters',
         'iso3166',
         'language_tags',
         'py-moneyed',
     ],
 
-    extras_require = {
-        'test-runner': ['detox'],
+    extras_require={
+        'test-runner': ['tox >= 3.7'],
     },
 
-    test_suite    = 'test',
-    test_loader   = 'nose.loader:TestLoader',
-    tests_require = [
+    test_suite='test',
+    test_loader='nose.loader:TestLoader',
+    tests_require=[
         'nose',
     ],
 
-    license = 'MIT',
+    license='MIT',
 
-    classifiers = [
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Text Processing :: Filters',
     ],
 
-    keywords =
-        'data validation, iso-3166, iso-4217, ietf language tags, bcp 47',
+    keywords=
+    'data validation, iso-3166, iso-4217, ietf language tags, bcp 47',
 
-    author          = 'Phoenix Zerin',
-    author_email    = 'phoenix.zerin@eflglobal.com',
+    author='Phoenix Zerin',
+    author_email='phx@phx.ph',
 )
-

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,3 +1,0 @@
-# coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals

--- a/test/filters_iso_test.py
+++ b/test/filters_iso_test.py
@@ -1,15 +1,10 @@
- # coding=utf-8
-from __future__ import absolute_import, division, print_function, \
-    unicode_literals
-
+import filters as f
+from filters.test import BaseFilterTestCase
+# noinspection PyProtectedMember
 from iso3166 import Country, countries_by_alpha3
 from language_tags import tags
 from language_tags.Tag import Tag
 from moneyed import Currency, get_currency
-from six import text_type
-
-import filters as f
-from filters.test import BaseFilterTestCase
 
 
 class CountryTestCase(BaseFilterTestCase):
@@ -196,10 +191,10 @@ class LocaleTestCase(BaseFilterTestCase):
         # documentation of its own).
         # https://github.com/mattcg/language-tags
         #
-        self.assertEqual(text_type(tag), 'en-cmn-Hant-HK')
-        self.assertEqual(text_type(tag.language), 'en')
-        self.assertEqual(text_type(tag.region), 'HK')
-        self.assertEqual(text_type(tag.script), 'Hant')
+        self.assertEqual(str(tag), 'en-cmn-Hant-HK')
+        self.assertEqual(str(tag.language), 'en')
+        self.assertEqual(str(tag.region), 'HK')
+        self.assertEqual(str(tag.script), 'Hant')
 
     def test_pass_case_insensitive(self):
         """
@@ -215,10 +210,10 @@ class LocaleTestCase(BaseFilterTestCase):
         self.assertIsInstance(tag, Tag)
         self.assertTrue(tag.valid)
 
-        self.assertEqual(text_type(tag), 'az-Arab-IR')
-        self.assertEqual(text_type(tag.language), 'az')
-        self.assertEqual(text_type(tag.region), 'IR')
-        self.assertEqual(text_type(tag.script), 'Arab')
+        self.assertEqual(str(tag), 'az-Arab-IR')
+        self.assertEqual(str(tag.language), 'az')
+        self.assertEqual(str(tag.region), 'IR')
+        self.assertEqual(str(tag.script), 'Arab')
 
     def test_fail_invalid_value(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, py36
+envlist = py35, py36, py37, py38
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
* Dropped support for Python 2.7.
* Added support for Python 3.7 and 3.8.
* Adopted PEP-8.
* Renamed fork to `phx-filters-iso`.