### PR TITLE
Pin GitHub Actions to commit digests 🪪

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
 
     steps:
       - name: Clone repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }


### PR DESCRIPTION
## What

Pins every GitHub Action in CI to an immutable commit SHA (with the resolved semver as a trailing comment) and enables Renovate digest pinning to keep them that way.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v7` | `@3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `astral-sh/setup-uv` | `@v8.3.2` | `@11f9893b081a58869d3b5fccaea48c9e9e46f990` # v8.3.2 |
| `actions/setup-python` | `@v6` | `@ece7cb06caefa5fff74198d8649806c4678c61a1` # v6.3.0 |

## Why

A floating tag (`@v7`) can be repointed at new commits after review, so CI silently runs code nobody vetted. A digest pin freezes the exact commit; `helpers:pinGitHubActionDigests` tells Renovate to keep new actions pinned and surface digest bumps as reviewable PRs.

## Verification

- No `uses: …@vN` tag pins remain in `.github/workflows/`.
- `build.yml` parses as YAML; `renovate.json` parses as JSON.
- Each SHA verified to be a commit object (not an annotated tag) and confirmed to carry its stated semver tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Claude Opus 4.8