### PR TITLE
Fix release skill's dist cleanup and stale refs

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Use when preparing or publishing a new release of phx-filters — covers release notes, version bump, build, PyPI upload, and GitHub release creation
+description: Use when preparing or publishing a new release of phx-filters-iso — covers release notes, version bump, build, PyPI upload, and GitHub release creation
 ---
 # Release
 
@@ -58,10 +58,13 @@ git checkout main && git pull
 
 ### 8. Build
 ```bash
-rm -f dist/*
+rm -rf dist
 uv build
 ```
-Artefacts land in `dist/`.
+Artefacts land in `dist/`. Nothing under `dist/` is tracked, so removing the
+whole directory is safe — and necessary: under zsh `rm -f dist/*` aborts with
+`no matches found` when `dist/` is empty or absent, and otherwise skips uv's
+`.gitignore`. `uv build` recreates both.
 
 ### 9. Tag and push
 ```bash
@@ -74,7 +77,7 @@ git push origin <version>
 
 **a. Append checksums to the release notes file:**
 ```bash
-sha256sum dist/phx_filters-* >> release-<version>.md
+shasum -a 256 dist/phx_filters_iso-* >> release-<version>.md
 ```
 
 **b. GPG-sign the document:**
@@ -85,8 +88,8 @@ gpg --clearsign --local-user "$GPG_KEY" release-<version>.md   # → release-<ve
 
 **c. Sign each build artefact:**
 ```bash
-for f in dist/phx_filters-*; do gpg --detach-sign --local-user "$GPG_KEY" "$f"; done
-# Creates dist/phx_filters-*.sig alongside each artefact
+for f in dist/phx_filters_iso-*; do gpg --detach-sign --local-user "$GPG_KEY" "$f"; done
+# Creates dist/phx_filters_iso-*.sig alongside each artefact
 ```
 
 **d. Build the release body** — concatenate the notes and the signed copy:
@@ -111,14 +114,32 @@ gh release create <version> dist/* \
 
 ### 11. Upload to PyPI
 ```bash
-uv publish --username __token__
+# Publishes only if the keyring can supply the token
+keyring get https://upload.pypi.org/legacy/ __token__ >/dev/null 2>&1 && \
+  uv publish --username __token__
 ```
+The token comes from the developer's keyring: `[tool.uv]` in `pyproject.toml`
+sets `keyring-provider = "subprocess"`, so uv shells out to a `keyring`
+executable on `PATH`. Run the check first — it exits non-zero when the keyring
+cannot supply the token, and prints nothing either way. Never echo the token to
+confirm it; that puts a live credential in the transcript.
+
+**If the check fails, stop here** and ask the developer to set
+`UV_PUBLISH_TOKEN` (which takes precedence over the keyring) and run the publish
+themselves. You cannot export it into their shell, and discovering this by
+running the upload means failing the release's one irreversible step.
 
 ### 12. Clean up
 ```bash
-rm release-<version>.md release-<version>.md.asc release-<version>-body.md
+rm -f release-<version>.md release-<version>.md.asc release-<version>-body.md
+rm -rf dist
 git checkout develop && git pull
 ```
+`-f` so a re-run does not fail on a file already removed. `dist` goes too — its
+artefacts and `.sig` files are on the GitHub release and PyPI by now. To correct
+a release afterwards, fetch those assets back with `gh release download
+<version>`: a rebuilt wheel may not be byte-identical, so its checksums would
+disagree with the published notes.
 
 ---
 


### PR DESCRIPTION
## What

Ports the release-skill fixes from [todofixthis/paddock#9](https://github.com/todofixthis/paddock/pull/9), found by running that skill to cut a paddock release, into this project's own `release` skill:

- Build step: `rm -f dist/*` → `rm -rf dist`. The old glob aborted under zsh when `dist/` was empty or absent, and skipped uv's generated `.gitignore` even when it matched.
- Checksums: `sha256sum` → `shasum -a 256` — the former is GNU-only and absent on a macOS host.
- Gate the PyPI publish on a keyring check, and document where the token comes from (`[tool.uv] keyring-provider = "subprocess"`), instead of discovering its absence at the release's one irreversible step.
- Clean up with a forgiving `rm -f` that survives a re-run, and remove the build directory so signatures don't outlive the release.

## Also found while porting

The frontmatter description and checksum/signing glob both said `phx_filters` instead of `phx_filters_iso` — this skill was the source that filters-django's copied wholesale (see [todofixthis/filters-django#33](https://github.com/todofixthis/filters-django/pull/33)), and neither copy actually matched its own package's wheel names. Corrected both to name this project, in the same spirit as the source commit's fix for a stale signing comment.

## Not ported

The paddock commit also repoints the tag step at `__init__.py` because paddock's version is `dynamic` in `pyproject.toml`. This project's version is static in `pyproject.toml` (set by `uv version`), so the existing wording is already correct — not changed.

## Verification

Not yet exercised end to end — these are documentation-only changes to a skill; the next release run is the real test, same as for the source commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A49i8Pr9YVQtbvUDw4daPd

---
_Generated by [Claude Code](https://claude.ai/code/session_01A49i8Pr9YVQtbvUDw4daPd)_